### PR TITLE
Handle consecutive char edits in one word

### DIFF
--- a/test/diff.spec.js
+++ b/test/diff.spec.js
@@ -48,6 +48,20 @@ describe('Diff', function(){
         expect(res).to.equal('wor<del data-operation-index="0">l</del>d');
       });
     }); // describe('When a single character is deleted from a word')
+
+    describe('When multiple consecutive characters change in a word', function(){
+      it('should inline the change when the max length allows it', function(){
+        res = cut('world', 'worried', undefined, undefined, undefined, 3);
+        expect(res).to.equal('wor<del data-operation-index="0">l</del>' +
+          '<ins data-operation-index="0">rie</ins>d');
+      });
+
+      it('should fall back when the max length is too small', function(){
+        res = cut('world', 'worried');
+        expect(res).to.equal('<del data-operation-index="0">world</del>' +
+          '<ins data-operation-index="0">worried</ins>');
+      });
+    }); // describe('When multiple consecutive characters change in a word')
   
     describe('Whitespace differences', function(){
       it('should collapse adjacent whitespace', function(){

--- a/test/diff.spec.js
+++ b/test/diff.spec.js
@@ -21,11 +21,33 @@ describe('Diff', function(){
       beforeEach(function(){
         res = cut('input', 'input 2');
       });
-  
+
       it('should mark the new letter', function(){
         expect(res).to.equal('input<ins data-operation-index="1"> 2</ins>');
       });
     }); // describe('When a letter is added')
+
+    describe('When a single character changes inside a word', function(){
+      it('should only wrap the changed character', function(){
+        res = cut('word', 'ward');
+        expect(res).to.equal('w<del data-operation-index="0">o</del>' +
+          '<ins data-operation-index="0">a</ins>rd');
+      });
+    }); // describe('When a single character changes inside a word')
+
+    describe('When a single character is inserted into a word', function(){
+      it('should only wrap the inserted character', function(){
+        res = cut('word', 'world');
+        expect(res).to.equal('wor<ins data-operation-index="0">l</ins>d');
+      });
+    }); // describe('When a single character is inserted into a word')
+
+    describe('When a single character is deleted from a word', function(){
+      it('should only wrap the deleted character', function(){
+        res = cut('world', 'word');
+        expect(res).to.equal('wor<del data-operation-index="0">l</del>d');
+      });
+    }); // describe('When a single character is deleted from a word')
   
     describe('Whitespace differences', function(){
       it('should collapse adjacent whitespace', function(){

--- a/test/from_port_source.spec.js
+++ b/test/from_port_source.spec.js
@@ -8,8 +8,7 @@ describe('The specs from the ruby source project', function(){
     it('should diff text', function(){
         var diff = cut('a word is here', 'a nother word is there');
         expect(diff).equal('a<ins data-operation-index="1"> nother</ins> word is ' +
-                '<del data-operation-index="3">here</del><ins data-operation-index="3">' +
-                'there</ins>');
+                '<ins data-operation-index="3">t</ins>here');
     });
 
     it('should insert a letter and a space', function(){

--- a/test/render_operations.spec.js
+++ b/test/render_operations.spec.js
@@ -98,8 +98,7 @@ describe('renderOperations', function(){
             var after = tokenize(['test!', '</b>', 'non-bold', '<b>', 'bold']);
             res = cut(before, after);
 
-            expect(res).to.equal('<del data-operation-index="0">test</del>' +
-                    '<ins data-operation-index="0">test!</ins></b>non-bold<b>' +
+            expect(res).to.equal('test<ins data-operation-index="0">!</ins></b>non-bold<b>' +
                     '<ins data-operation-index="2">bold</ins>');
         });
 


### PR DESCRIPTION
### Background
The diff output was highlighting entire words when only a small part of the word changed, which reduced readability and made minor edits look larger than they are. We wanted inline highlighting within a word while keeping existing HTML/tag safety behavior.

### Implementation
Implemented inline diffing for a single consecutive span of changes inside a word. The logic finds common prefix/suffix and wraps only the changed span in `<ins>`/`<del>`, with a configurable maximum span length and a fallback to full‑token replacement for non‑eligible cases.

### Testing
Added unit tests covering inline substitution, insertion, deletion, and multi‑character consecutive span changes, including the max‑length fallback.